### PR TITLE
Upgrade postgres postgis and python to match current Heroku cedar-14

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               settings['use_geodjango'],
             ]
 
-  config.vm.provision 'build',
+  config.vm.provision 'bash',
             type: 'shell',
             path: 'config/vagrant/bash_setup.sh'
 

--- a/config/vagrant/build_dependency_setup.sh
+++ b/config/vagrant/build_dependency_setup.sh
@@ -7,11 +7,11 @@ echo "=== Begin Vagrant Provisioning using 'config/vagrant/build_dependency_setu
 USE_GEODJANGO=$1
 
 # Install build dependencies for a sane build environment
-apt-get -y update
-apt-get -y install autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev
+apt-get -y -qq update
+apt-get -y -qq install autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev
 
 # Other things that we may need installed before anything else.
-apt-get install -y libmemcached-dev
+apt-get -y -qq install libmemcached-dev
 
 if [ $USE_GEODJANGO = 'true' ]
 then
@@ -19,7 +19,7 @@ then
   echo ""
   echo "Installing Geospatial libraries"
   echo ""
-  apt-get -y install binutils libproj-dev gdal-bin
+  apt-get -y -qq install binutils libproj-dev gdal-bin
 fi
 
 echo "=== End Vagrant Provisioning using 'config/vagrant/build_dependency_setup.sh'"

--- a/config/vagrant/git_setup.sh
+++ b/config/vagrant/git_setup.sh
@@ -7,8 +7,8 @@ echo "=== Begin Vagrant Provisioning using 'config/vagrant/git_setup.sh'"
 # Install Git if not available
 if [ -z `which git` ]; then
   echo "===== Installing Git"
-  apt-get -y update
-  apt-get -y install git-core
+  apt-get -y -qq update
+  apt-get -y -qq install git-core
 fi
 
 echo "=== End Vagrant Provisioning using 'config/vagrant/git_setup.sh'"

--- a/config/vagrant/python_setup.sh
+++ b/config/vagrant/python_setup.sh
@@ -8,24 +8,24 @@
 
 echo "=== Begin Vagrant Provisioning using 'config/vagrant/python_setup.sh'"
 
-apt-get update -y
+apt-get -qq -y update
 
 # Python dev packages
-apt-get install -y python python-dev python-setuptools python-pip
+apt-get -qq -y install python python-dev python-setuptools python-pip
 
 # Install Python 3 if the runtime.txt file specifies it.
 if [[ -f /vagrant/runtime.txt ]]; then
   python_runtime=$(head -n 1 /vagrant/runtime.txt)
-  if [[ $python_runtime =~ ^python-3\.5 ]]; then
-    # Python 3.5 not yet in the official repositories list, so use this:
+  if [[ $python_runtime =~ ^python-3\.6 ]]; then
+    # Python 3.6 not yet in the official repositories list, so use this:
     add-apt-repository ppa:fkrull/deadsnakes
-    apt-get update
-    apt-get install -y python3.5 python3.5-dev
+    apt-get -qq -y update
+    apt-get -qq  -y install python3.6 python3.6-dev
   fi
 fi
 
 # Dependencies for image processing with Pillow (drop-in replacement for PIL)
 # supporting: jpeg, tiff, png, freetype, littlecms
-apt-get install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev
+apt-get -qq install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev
 
 echo "=== End Vagrant Provisioning using 'config/vagrant/python_setup.sh'"

--- a/config/vagrant/virtualenv_setup.sh
+++ b/config/vagrant/virtualenv_setup.sh
@@ -49,8 +49,8 @@ else
     # If runtime.txt specifies Python 3, use that for the virtualenv:
     if [[ -f /vagrant/runtime.txt ]]; then
         python_runtime=$(head -n 1 /vagrant/runtime.txt)
-        if [[ $python_runtime =~ ^python-3\.5 ]]; then
-            PYTHON_VERSION='python3.5'
+        if [[ $python_runtime =~ ^python-3\.6 ]]; then
+            PYTHON_VERSION='python3.6'
         fi
     fi
 


### PR DESCRIPTION
Hi!

Thanks for a really helpful repo. I had a couple of issues when trying to use this to setup a dev environment that looks like the current cedar-14 stack, so I thought I'd PR them back. They are:

1. I fixed a typo in the build stage setup that meant the bash step wasn't running
2. I've updated the listed libraries to match what Heroku runs at the moment
3. I've added the `postgis-scripts` package to the list that's installed when geodjango is true, because it seems the extension lives there now
4. I've added a step to make the django db user a superuser - without this it can't create the postgis extension, and it tries to do this on every test run. This is ok for my use case, but I guess it's more contentious, so I'm happy to remove this to a documented quirk instead if you'd prefer?
5. I've quietened down all of the apt-get steps a bit, with `-qq` because it made it easier to debug what was going on